### PR TITLE
Add object-fit class to thumbnail images

### DIFF
--- a/components/utils/Item.js
+++ b/components/utils/Item.js
@@ -233,7 +233,7 @@ const Item = ({
                       src={meta.og && image()}
                       alt=""
                       width="270"
-                      className="rounded-md w-full h-[150px] scale-on-hover duration-500"
+                      className="rounded-md w-full h-[150px] object-cover scale-on-hover duration-500"
                     />
                   </a>
                 </Link>
@@ -345,7 +345,7 @@ const Item = ({
                         src={meta.og && image()}
                         alt=""
                         width="300"
-                        className="rounded-md w-full mb-2 h-[157.5px] scale-on-hover duration-500"
+                        className="rounded-md w-full mb-2 h-[157.5px] object-cover scale-on-hover duration-500"
                       />
                     </a>
                   </Link>


### PR DESCRIPTION
Hey Savio,

Neat app! I noticed that the thumbnails for the cheat sheet items were stretched:

![26CB151A-1CC9-4E0F-B09A-660832EC7CA0](https://user-images.githubusercontent.com/47185402/149208487-f9116a44-fc01-42c9-8317-40f81cd2a943.jpeg)

This can be solved using the same `<img>` element by adding the Tailwind class: `object-cover`. It will apply this CSS rule to it: `object-fit: cover;` (it functions like `background-size: cover;` on a `<div>` element).