### PR TITLE
Remove body padding to prevent modal shifting content.

### DIFF
--- a/styles/App.css
+++ b/styles/App.css
@@ -20,6 +20,12 @@
   outline: none !important;
 }
 
+/* Body */
+body {
+  /* Prevent modal shifting content */
+  padding-right: 0 !important;
+}
+
 /* App */
 #root,
 html,


### PR DESCRIPTION
Currently when you click on the sign in button, or anything else that opens a modal, you can see the page content shift left by 15px. This is fixed by preventing the body from adding that padding.